### PR TITLE
Adding Storage#get_unspent_txouts_for_address method.

### DIFF
--- a/lib/bitcoin/storage/storage.rb
+++ b/lib/bitcoin/storage/storage.rb
@@ -356,6 +356,16 @@ module Bitcoin::Storage
         get_txouts_for_hash160(hash160, unconfirmed)
       end
 
+      # collect all unspent txouts containing a
+      # standard tx to given +address+
+      def get_unspent_txouts_for_address(address, unconfirmed = false)
+        txouts = self.get_txouts_for_address(address, unconfirmed)
+        txouts.select! do |t|
+          not t.get_next_in
+        end
+        txouts
+      end
+
       # get balance for given +hash160+
       def get_balance(hash160, unconfirmed = false)
         txouts = get_txouts_for_hash160(hash160, unconfirmed)

--- a/spec/bitcoin/storage/storage_spec.rb
+++ b/spec/bitcoin/storage/storage_spec.rb
@@ -161,7 +161,7 @@ Bitcoin::network = :testnet
         it "should store tx" do
           @store.store_tx(@tx, false).should != false
         end
-        
+
         it "should not store tx if already stored and return existing id" do
           id = @store.store_tx(@tx, false)
           @store.store_tx(@tx, false).should == id
@@ -270,6 +270,11 @@ Bitcoin::network = :testnet
 
       it "should get txouts for address" do
         @store.get_txouts_for_address(@key2.addr, true)
+          .should == [@block.tx[1].out[0]]
+      end
+
+      it "should get unspent txouts for address" do
+        @store.get_unspent_txouts_for_address(@key2.addr, true)
           .should == [@block.tx[1].out[0]]
       end
 


### PR DESCRIPTION
This method returns all transactions related to one address that are not yet spent.
