### PR TITLE
fix handling incoming connections by node

### DIFF
--- a/lib/bitcoin/network/connection_handler.rb
+++ b/lib/bitcoin/network/connection_handler.rb
@@ -90,8 +90,7 @@ module Bitcoin::Network
       log.info { "Established #{@direction} connection" }
       @node.connections << self
       @state = :handshake
-      # incoming connections wait to receive a version
-      send_version if outgoing?
+      send_version
     rescue Exception
       log.fatal { "Error in #begin_handshake" }
       p $!; puts *$@

--- a/lib/bitcoin/network/node.rb
+++ b/lib/bitcoin/network/node.rb
@@ -490,7 +490,7 @@ module Bitcoin::Network
 
     # should the node accept new incoming connections?
     def accept_connections?
-      connections.select(&:incoming?).size >= config[:max][:connections_in]
+      connections.select(&:incoming?).size < config[:max][:connections_in]
     end
 
   end


### PR DESCRIPTION
So I may have missed something, but it seems to be that in current version bin/bitcoin_node is incapable of accepting incoming connections.

One thing is this max connections_in check which seems to be on the wrong side.

And the other is I don't see where it ever sends version for an incoming connection. So I changed it to send after connection is initialized, just as it is for outgoing. If there was any reason to separate those cases then please explain why so I can fix it in another way (and put some comment with explanation).
