### PR TITLE
fix on_getblocks

### DIFF
--- a/lib/bitcoin/network/connection_handler.rb
+++ b/lib/bitcoin/network/connection_handler.rb
@@ -223,8 +223,7 @@ module Bitcoin::Network
 
       return  unless depth && depth <= @node.store.get_depth
       range = (depth+1..depth+500)
-      blocks = @node.store.db[:blk].where(chain: 0, depth: range).select(:hash).all +
-        [@node.store.db[:blk].select(:hash)[chain: 0, depth: depth+502]]
+      blocks = @node.store.db[:blk].where(chain: 0, depth: range).order(:depth).select(:hash).all
       send_inv(:block, *blocks.map {|b| b[:hash].hth })
     end
 


### PR DESCRIPTION
in prev version was ignored by bitcoin core and others because it was
returning 501 blocks, it seems that we don't need to add head hash, and
just providing 500 children hashes is ok, it successfully synced
bitcoin-qt client in this form 
