### PR TITLE
always pop extra item from stack to fix OP_CHECKMULTISIG handling

### DIFF
--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -1199,7 +1199,8 @@ class Bitcoin::Script
     sigs = pop_string(n_sigs)
     drop_sigs = sigs.dup
 
-    @stack.pop if @stack[-1] && cast_to_bignum(@stack[-1]) == 0 # remove OP_0 from stack
+    # Bitcoin-core removes an extra item from the stack
+    @stack.pop
 
     subscript = sighash_subscript(drop_sigs)
 


### PR DESCRIPTION
The description of OP_CHECKMULTISIG at https://en.bitcoin.it/wiki/Script#Crypto is the best I could find but seems to indicate that an extra item should always be removed from the stack, not just an OP_0.  This change allows the new tests added by the previous commit to pass and my testnet node to get past the block containing b5cd9e999fb51e29ab741b1e1732f1d4d038bc493ffbced85a252533a2c2ab0c
